### PR TITLE
Verifier tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package
           make -j4 && make install
 
-      - name: test prover for linux
+      - name: test rapidsnark
         run: |
           set -x
           set -e
@@ -168,7 +168,7 @@ jobs:
           cmake .. -DTARGET_PLATFORM=macos_arm64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package_macos_arm64
           make -j4 && make install
 
-      - name: test prover
+      - name: test rapidsnark
         run: |
           set -x
           set -e
@@ -269,7 +269,7 @@ jobs:
           cmake .. -DTARGET_PLATFORM=macos_x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package_macos_x86_64
           make -j4 && make install
 
-      - name: test prover
+      - name: test rapidsnark
         run: |
           set -x
           set -e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
           mkdir -p build_prover && cd build_prover
           cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package
           make -j4 && make install
+          ctest --rerun-failed --output-on-failure
 
       - name: test rapidsnark
         run: |
@@ -167,6 +168,7 @@ jobs:
           mkdir -p build_prover_macos_arm64 && cd build_prover_macos_arm64
           cmake .. -DTARGET_PLATFORM=macos_arm64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package_macos_arm64
           make -j4 && make install
+          ctest --rerun-failed --output-on-failure
 
       - name: test rapidsnark
         run: |
@@ -268,6 +270,7 @@ jobs:
           mkdir -p build_prover_macos_x86_64 && cd build_prover_macos_x86_64
           cmake .. -DTARGET_PLATFORM=macos_x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package_macos_x86_64
           make -j4 && make install
+          ctest --rerun-failed --output-on-failure
 
       - name: test rapidsnark
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,15 @@ jobs:
         run: |
           set -x
           set -e
-          npm install -g snarkjs
           package/bin/prover testdata/circuit_final.zkey testdata/witness.wtns proof.json public.json
-          snarkjs groth16 verify testdata/verification_key.json public.json proof.json
+          package/bin/verifier testdata/verification_key.json public.json proof.json
+          # make a wrong public.json by decrementing the first element by 1
+          (value_0=$(jq '.[0]' public.json | tr -d '"') && value_0=$(echo "$value_0 - 1" | BC_LINE_LENGTH=100 bc) && jq --arg value_0 "$value_0" '.[0] = $value_0' public.json) > public_bad.json
+          set +e
+          package/bin/verifier testdata/verification_key.json public_bad.json proof.json
+          exit_code=$?
+          set -e
+          [ $exit_code -ne 0 ]
 
       - name: upload Linux amd64 dev artifacts
         if: github.event_name != 'release'
@@ -166,9 +172,15 @@ jobs:
         run: |
           set -x
           set -e
-          npm install -g snarkjs
           package_macos_arm64/bin/prover testdata/circuit_final.zkey testdata/witness.wtns proof.json public.json
-          snarkjs groth16 verify testdata/verification_key.json public.json proof.json
+          package_macos_arm64/bin/verifier testdata/verification_key.json public.json proof.json
+          # make a wrong public.json by decrementing the first element by 1
+          (value_0=$(jq '.[0]' public.json | tr -d '"') && value_0=$(echo "$value_0 - 1" | BC_LINE_LENGTH=100 bc) && jq --arg value_0 "$value_0" '.[0] = $value_0' public.json) > public_bad.json
+          set +e
+          package_macos_arm64/bin/verifier testdata/verification_key.json public_bad.json proof.json
+          exit_code=$?
+          set -e
+          [ $exit_code -ne 0 ]
 
       - name: upload macOS arm64 dev artifacts
         if: github.event_name != 'release'
@@ -261,9 +273,15 @@ jobs:
         run: |
           set -x
           set -e
-          npm install -g snarkjs
           package_macos_x86_64/bin/prover testdata/circuit_final.zkey testdata/witness.wtns proof.json public.json
-          snarkjs groth16 verify testdata/verification_key.json public.json proof.json
+          package_macos_x86_64/bin/verifier testdata/verification_key.json public.json proof.json
+          # make a wrong public.json by decrementing the first element by 1
+          (value_0=$(jq '.[0]' public.json | tr -d '"') && value_0=$(echo "$value_0 - 1" | BC_LINE_LENGTH=100 bc) && jq --arg value_0 "$value_0" '.[0] = $value_0' public.json) > public_bad.json
+          set +e
+          package_macos_x86_64/bin/verifier testdata/verification_key.json public_bad.json proof.json
+          exit_code=$?
+          set -e
+          [ $exit_code -ne 0 ]
 
       - name: upload macOS x86_64 dev artifacts
         if: github.event_name != 'release'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(cmake/platform.cmake)
 set(USE_ASM    ON CACHE BOOL "Use asm implementation for Fr and Fq")
 set(USE_OPENMP ON CACHE BOOL "Use OpenMP")
 
-project(rapidsnark LANGUAGES CXX ASM)
+project(rapidsnark LANGUAGES CXX C ASM)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -63,3 +63,5 @@ install(FILES "${GMP_LIB_DIR}/${GMP_LIB_FILE}"
 
 install(FILES src/prover.h src/verifier.h
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+
+enable_testing()

--- a/README.md
+++ b/README.md
@@ -177,6 +177,23 @@ The prover is much faster that snarkjs and faster than bellman.
 
 [TODO] Some comparative tests should be done.
 
+## Run tests
+
+You need to perform all the steps from the
+[Compile prover in standalone mode](#compile-prover-in-standalone-mode) section.
+After that you can run tests with the following command from the build
+directory:
+
+```sh
+cmake --build . --parallel && ctest --rerun-failed --output-on-failure
+```
+
+To run just the `test_public_size` test for custom zkey to measure the
+performance, you can run the following command from the build directory:
+
+```sh
+src/test_public_size ../testdata/circuit_final.zkey 86
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ After that you can run tests with the following command from the build
 directory:
 
 ```sh
+# Make sure you are in the build directory
+# ./build_prover for linux, ./build_prover_macos_arm64 for macOS.
 cmake --build . --parallel && ctest --rerun-failed --output-on-failure
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,6 +132,12 @@ if(USE_SODIUM)
 endif()
 
 
+enable_testing()
+add_executable(test_public_size test_public_size.c)
+target_link_libraries(test_public_size rapidsnarkStaticFrFq)
+add_test(NAME test_public_size COMMAND test_public_size circuit_final.zkey 86
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/testdata)
+
 if(OpenMP_CXX_FOUND)
 
     if(TARGET_PLATFORM MATCHES "android")
@@ -142,16 +148,10 @@ if(OpenMP_CXX_FOUND)
     elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
         target_link_libraries(prover OpenMP::OpenMP_CXX)
         target_link_libraries(verifier OpenMP::OpenMP_CXX)
+        target_link_libraries(test_public_size OpenMP::OpenMP_CXX)
     endif()
 
 endif()
 
 
 add_executable(test_prover test_prover.cpp)
-
-enable_testing()
-
-add_executable(test_public_size test_public_size.c)
-target_link_libraries(test_public_size rapidsnarkStaticFrFq)
-add_test(NAME test_public_size COMMAND test_public_size circuit_final.zkey 86
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/testdata)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,3 +148,10 @@ endif()
 
 
 add_executable(test_prover test_prover.cpp)
+
+enable_testing()
+
+add_executable(test_public_size test_public_size.c)
+target_link_libraries(test_public_size rapidsnarkStaticFrFq)
+add_test(NAME test_public_size COMMAND test_public_size circuit_final.zkey 86
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/testdata)

--- a/src/test_public_size.c
+++ b/src/test_public_size.c
@@ -1,0 +1,130 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <time.h>
+#include "prover.h"
+
+int
+test_groth16_public_size(const char *zkey_fname, size_t *public_size) {
+    int ret_val = 0;
+    const int error_sz = 256;
+    char error_msg[error_sz];
+
+    int fd = open(zkey_fname, O_RDONLY);
+    if (fd == -1) {
+        printf("Error: %s\n", "open");
+        ret_val = 1;
+        goto cleanup;
+    }
+
+    struct stat sb = {0};
+    if (fstat(fd, &sb) == -1) {
+        printf("Error: %s\n", "fstat");
+        ret_val = 1;
+        goto cleanup;
+    }
+
+    void *buf = malloc(sb.st_size);
+    if (buf == NULL) {
+        printf("Error: %s\n", "malloc");
+        ret_val = 1;
+        goto cleanup;
+    }
+
+    ssize_t bytes_read = read(fd, buf, sb.st_size);
+    if (bytes_read != sb.st_size) {
+        printf("Error: %s\n", "read");
+        ret_val = 1;
+        goto cleanup;
+    }
+
+    int ok = groth16_public_size_for_zkey_buf(buf, sb.st_size, public_size, error_msg, error_sz);
+    if (ok == 0) {
+        printf("Public size: %lu\n", *public_size);
+    } else {
+        printf("Error: %s\n", error_msg);
+        ret_val = 1;
+        goto cleanup;
+    }
+
+cleanup:
+
+    if (fd != -1)
+        if (close(fd) == -1)
+            printf("Error: %s\n", "close");
+
+    return ret_val;
+}
+
+int
+test_groth16_public_size_for_zkey_file(const char *zkey_fname,
+                                       size_t *public_size) {
+    const int err_ln = 256;
+    char error_msg[err_ln];
+    int ret = groth16_public_size_for_zkey_file(zkey_fname, public_size, error_msg, err_ln);
+
+    if (ret == 0) {
+        printf("Public size: %lu\n", *public_size);
+    } else {
+        printf("Error: %s\n", error_msg);
+    }
+    return ret;
+}
+
+int
+main(int argc, char *argv[]) {
+    if (argc < 3) {
+        printf("Usage: %s <zkey_file> <expected_inputs>\n", argv[0]);
+        return 1;
+    }
+
+    long want_inputs = 0;
+    want_inputs = strtol(argv[2], NULL, 10);
+
+    int ret_val = 0;
+    clock_t start = clock();
+
+    size_t public_size = 0;
+
+    int test_groth16_public_size_ok =
+            test_groth16_public_size(argv[1], &public_size);
+    if (test_groth16_public_size_ok) {
+        printf("test_groth16_public_size failed\n");
+        ret_val = 1;
+    } else {
+        clock_t end = clock();
+        printf("test_groth16_public_size succeeded in %f seconds\n",
+               (double)(end - start) / CLOCKS_PER_SEC);
+    }
+
+    if (public_size != want_inputs) {
+        printf("test_groth16_public_size expected inputs: %ld\n", want_inputs);
+        printf("test_groth16_public_size actual inputs: %lu\n", public_size);
+        ret_val = 1;
+    }
+
+    public_size = 0;
+    start = clock();
+    int test_groth16_public_size_for_zkey_file_ok =
+            test_groth16_public_size_for_zkey_file(argv[1], &public_size);
+    if (test_groth16_public_size_for_zkey_file_ok) {
+        printf("test_groth16_public_size_for_zkey_file failed\n");
+        ret_val = 1;
+    } else {
+        clock_t end = clock();
+        printf("test_groth16_public_size_for_zkey_file succeeded in %f seconds\n",
+               (double)(end - start) / CLOCKS_PER_SEC);
+    }
+
+    if (public_size != want_inputs) {
+        printf("test_groth16_public_size_for_zkey_file expected inputs: %ld\n", want_inputs);
+        printf("test_groth16_public_size_for_zkey_file actual inputs: %lu\n", public_size);
+        ret_val = 1;
+    }
+
+    return ret_val;
+}
+

--- a/src/test_public_size.c
+++ b/src/test_public_size.c
@@ -3,10 +3,10 @@
  * groth16_public_size_for_zkey_buf.
  *
  * Run it as
- * ./test_public_size <zkey_file> <expected_inputs>
- * it will read the number of inputs from the zkey file and compare it with
- * the expected number of inputs. Return 0 if success. Return 1 if failure.
- * Also prints the time taken by each function.
+ * ./test_public_size <zkey_file> <expected_pub_size>
+ * it will calculate the required public signals buffer size from the zkey file
+ * and compare it with the expected one. Return 0 if success.
+ * Return 1 if failure. Also prints the time taken by each function.
  */
 
 #include <stdio.h>
@@ -88,12 +88,12 @@ test_groth16_public_size_for_zkey_file(const char *zkey_fname,
 int
 main(int argc, char *argv[]) {
     if (argc < 3) {
-        printf("Usage: %s <zkey_file> <expected_inputs>\n", argv[0]);
+        printf("Usage: %s <zkey_file> <expected_pub_size>\n", argv[0]);
         return 1;
     }
 
-    long want_inputs = 0;
-    want_inputs = strtol(argv[2], NULL, 10);
+    long want_pub_size = 0;
+    want_pub_size = strtol(argv[2], NULL, 10);
 
     int ret_val = 0;
     clock_t start = clock();
@@ -111,9 +111,11 @@ main(int argc, char *argv[]) {
                (double)(end - start) / CLOCKS_PER_SEC);
     }
 
-    if (public_size != want_inputs) {
-        printf("test_groth16_public_size expected inputs: %ld\n", want_inputs);
-        printf("test_groth16_public_size actual inputs: %lu\n", public_size);
+    if (public_size != want_pub_size) {
+        printf("test_groth16_public_size expected public signals buf size: %ld\n",
+               want_pub_size);
+        printf("test_groth16_public_size actual public signals buf size: %lu\n",
+               public_size);
         ret_val = 1;
     }
 
@@ -130,9 +132,11 @@ main(int argc, char *argv[]) {
                (double)(end - start) / CLOCKS_PER_SEC);
     }
 
-    if (public_size != want_inputs) {
-        printf("test_groth16_public_size_for_zkey_file expected inputs: %ld\n", want_inputs);
-        printf("test_groth16_public_size_for_zkey_file actual inputs: %lu\n", public_size);
+    if (public_size != want_pub_size) {
+        printf("test_groth16_public_size_for_zkey_file expected public signals buf size: %ld\n",
+               want_pub_size);
+        printf("test_groth16_public_size_for_zkey_file actual public signals buf size: %lu\n",
+               public_size);
         ret_val = 1;
     }
 

--- a/src/test_public_size.c
+++ b/src/test_public_size.c
@@ -1,3 +1,14 @@
+/**
+ * Test functions groth16_public_size_for_zkey_file and
+ * groth16_public_size_for_zkey_buf.
+ *
+ * Run it as
+ * ./test_public_size <zkey_file> <expected_inputs>
+ * it will read the number of inputs from the zkey file and compare it with
+ * the expected number of inputs. Return 0 if success. Return 1 if failure.
+ * Also prints the time taken by each function.
+ */
+
 #include <stdio.h>
 #include <fcntl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Add integration tests to check `verifier` for correct and incorrect inputs.

Add unit tests for functions `groth16_public_size_for_zkey_file` and `groth16_public_size_for_zkey_buf`. Also enable ctest functionality that would enable us to write unit tests for different parts and run them as part for the cmake pipeline.