### PR TITLE
fix: README.md hyperlinks interchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # rapidsnark
 
-Rapidsnark is a zkSnark proof generation written in C++ and intel/arm assembly. That generates proofs created in [circom](https://github.com/iden3/snarkjs) and [snarkjs](https://github.com/iden3/circom) very fast.
+Rapidsnark is a zkSnark proof generation written in C++ and intel/arm assembly. That generates proofs created in [circom](https://github.com/iden3/circom) and [snarkjs](https://github.com/iden3/snarkjs) very fast.
 
 ## Dependencies
 


### PR DESCRIPTION
Swapped links for circom and snarkjs