### PR TITLE
fix: fix gmp build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ git submodule init
 git submodule update
 ./build_gmp.sh android
 mkdir build_prover_android && cd build_prover_android
-cmake .. -DTARGET_PLATFORM=ANDROID -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package_android
+cmake .. -DTARGET_PLATFORM=ANDROID -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package_android -DBUILD_TESTS=OFF
 make -j4 && make install
 ```
 
@@ -107,7 +107,7 @@ git submodule init
 git submodule update
 ./build_gmp.sh ios
 mkdir build_prover_ios && cd build_prover_ios
-cmake .. -GXcode -DTARGET_PLATFORM=IOS -DCMAKE_INSTALL_PREFIX=../package_ios
+cmake .. -GXcode -DTARGET_PLATFORM=IOS -DCMAKE_INSTALL_PREFIX=../package_ios -DBUILD_TESTS=OFF
 xcodebuild -destination 'generic/platform=iOS' -scheme rapidsnarkStatic -project rapidsnark.xcodeproj -configuration Release
 ```
 Open generated Xcode project and compile prover.
@@ -121,7 +121,7 @@ git submodule init
 git submodule update
 ./build_gmp.sh ios_simulator
 mkdir build_prover_ios_simulator && cd build_prover_ios_simulator
-cmake .. -GXcode -DTARGET_PLATFORM=IOS -DCMAKE_INSTALL_PREFIX=../package_ios_simulator -DUSE_ASM=NO
+cmake .. -GXcode -DTARGET_PLATFORM=IOS -DCMAKE_INSTALL_PREFIX=../package_ios_simulator -DUSE_ASM=NO -DBUILD_TESTS=OFF
 xcodebuild -destination 'generic/platform=iOS Simulator' -scheme rapidsnarkStatic -project rapidsnark.xcodeproj
 ```
 

--- a/build_gmp.sh
+++ b/build_gmp.sh
@@ -128,7 +128,11 @@ build_android()
         return 1
     fi
 
-    export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+    if [ "$(uname)" == "Darwin" ]; then
+        export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/darwin-x86_64
+    else
+        export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+    fi
 
     export TARGET=aarch64-linux-android
     export API=21
@@ -173,7 +177,11 @@ build_android_x86_64()
         return 1
     fi
 
-    export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+    if [ "$(uname)" == "Darwin" ]; then
+        export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/darwin-x86_64
+    else
+        export TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+    fi
 
     export TARGET=x86_64-linux-android
     export API=21

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -79,7 +79,7 @@ else()
 
 endif()
 
-if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND NOT TARGET_PLATFORM MATCHES "^android(_x86_64)?")
     set(GMP_DEFINIONS -D_LONG_LONG_LIMB)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 if(USE_ASM AND ARCH MATCHES "x86_64")
 
-    if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND NOT TARGET_PLATFORM MATCHES "^android(_x86_64)?")
         set(NASM_FLAGS -fmacho64 --prefix _)
     else()
         set(NASM_FLAGS -felf64 -DPIC)


### PR DESCRIPTION
## Problems
The current cmake/`build_gmp.sh` doesn't work for macOS to build for Android targets
It is pretty similar to this issue https://github.com/0xPolygonID/witnesscalc/pull/26

## Solution
- refer to `witnesscalc`
https://github.com/0xPolygonID/witnesscalc/blob/4a789880727aa0df50f1c4ef78ec295f5a30a15e/build_gmp.sh#L131C1-L135C7
- find the correct toolchain on macOS
- refer to https://github.com/0xPolygonID/witnesscalc/blob/4a789880727aa0df50f1c4ef78ec295f5a30a15e/cmake/platform.cmake#L65
- https://github.com/0xPolygonID/witnesscalc/blob/4a789880727aa0df50f1c4ef78ec295f5a30a15e/src/CMakeLists.txt#L20