### PR TITLE
Remove unused vk_gamma2 from zkey header

### DIFF
--- a/src/zkey_utils.cpp
+++ b/src/zkey_utils.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<Header> loadHeader(BinFileUtils::BinFile *f) {
     h->vk_alpha1 = f->read(h->n8q*2);
     h->vk_beta1 = f->read(h->n8q*2);
     h->vk_beta2 = f->read(h->n8q*4);
-    h->vk_gamma2 = f->read(h->n8q*4);
+    f->read(h->n8q*4);
     h->vk_delta1 = f->read(h->n8q*2);
     h->vk_delta2 = f->read(h->n8q*4);
     f->endReadSection();


### PR DESCRIPTION
vk_gamma2 in ZKeyUtils::Header was never used by the prover, but still parsed and stored a pointer to it. This change removes the field from the header and stops storing the pointer, while still reading the corresponding bytes from section 2 to keep the file cursor and endReadSection checks correct. The .zkey format and the layout of the Groth16 verifying key remain fully respected, but the header no longer exposes a dead field.