### PR TITLE
fix: throw Error object for unsupported platform

### DIFF
--- a/tasksfile.js
+++ b/tasksfile.js
@@ -14,13 +14,13 @@ function createFieldSources() {
         sh("nasm -fmacho64 --prefix _ fq.asm", {cwd: "build"});
     }  else if (process.platform === "linux") {
         sh("nasm -felf64 fq.asm", {cwd: "build"});
-    } else throw("Unsupported platform");
+    } else throw new Error("Unsupported platform");
 
     if (process.platform === "darwin") {
         sh("nasm -fmacho64 --prefix _ fr.asm", {cwd: "build"});
     }  else if (process.platform === "linux") {
         sh("nasm -felf64 fr.asm", {cwd: "build"});
-    } else throw("Unsupported platform");
+    } else throw new Error("Unsupported platform");
 }
 
 function buildPistache() {


### PR DESCRIPTION
Replace string throws with proper Error objects for unsupported platform cases. This follows Node.js best practices and improves stack traces/debuggability without changing runtime behavior.