### PR TITLE
fix: align package.json license with repository license text

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fast"
   ],
   "author": "Jordi Baylina",
-  "license": "GPL-3.0",
+  "license": "LGPL-3.0",
   "devDependencies": {
     "tasksfile": "^5.1.1"
   },


### PR DESCRIPTION
This PR updates the `license` field in `package.json`.

Right now `package.json` says `GPL-3.0`, but the repository includes LGPL license text in `COPYING`, so the package metadata appears to be out of sync with the repository’s license materials.

Change in this PR:
- `license: "GPL-3.0"` -> `license: "LGPL-3.0"`

The goal is just to align the npm/package metadata with the existing repository license text and avoid confusion for downstream users.

If you want, I’m happy to adjust this further if you prefer a more specific SPDX variant.
