### PR TITLE
fixes linux build(gcc16) with linux build make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ host:
 	cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package && \
 	make -j$(nproc) -vvv && make install
 
+host_linux:
+	rm -rf build_prover && mkdir build_prover && cd build_prover && \
+	cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package -DBUILD_LINUX=ON && \
+	make -j$(nproc) -vvv && make install
+
 host_noasm:
 	rm -rf build_prover_noasm && mkdir build_prover_noasm && cd build_prover_noasm && \
 		cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../package_noasm -DUSE_ASM=NO && \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,11 @@ if(DEFINED BITS_PER_CHUNK)
     add_definitions(-DMSM_BITS_PER_CHUNK=${BITS_PER_CHUNK})
 endif()
 
+option(BUILD_LINUX "Build for Linux (adds cstdint includes needed by GCC 16+)" OFF)
+if(BUILD_LINUX)
+    add_definitions(-DRAPIDSNARK_LINUX)
+endif()
+
 if(USE_ASM AND ARCH MATCHES "x86_64")
 
     if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin" AND NOT TARGET_PLATFORM MATCHES "^android(_x86_64)?")

--- a/src/binfile_utils.cpp
+++ b/src/binfile_utils.cpp
@@ -7,6 +7,9 @@
 #include <memory.h>
 #include <stdexcept>
 
+#ifdef RAPIDSNARK_LINUX
+#include <cstdint>
+#endif
 #include "binfile_utils.hpp"
 #include "fileloader.hpp"
 

--- a/src/binfile_utils.hpp
+++ b/src/binfile_utils.hpp
@@ -4,6 +4,9 @@
 #include <map>
 #include <vector>
 #include <memory>
+#ifdef RAPIDSNARK_LINUX
+#include <cstdint>
+#endif
 #include "fileloader.hpp"
 
 namespace BinFileUtils {

--- a/src/random_generator.hpp
+++ b/src/random_generator.hpp
@@ -8,6 +8,9 @@
 #else
 
 #include <random>
+#ifdef RAPIDSNARK_LINUX
+#include <cstdint>
+#endif
 
 inline void
 randombytes_buf(void * const buf, const size_t size)

--- a/src/zkey_utils.cpp
+++ b/src/zkey_utils.cpp
@@ -1,3 +1,6 @@
+#ifdef RAPIDSNARK_LINUX
+#include <cstdint>
+#endif
 #include <stdexcept>
 
 #include "zkey_utils.hpp"


### PR DESCRIPTION
This fixes building on linux and the latest fedora kernels with gcc16

## Problem

Rapidsnark failed to compile on systems with GCC 16 due to two issues:

1. **GMP 6.3.0 `configure` fails** — The "long long reliability test 1" in GMP's `configure` uses `-pedantic`, which GCC 16 rejects because of stricter enforcement of forward declaration argument matching.

2. **Missing `#include <cstdint>`** — GCC 16 no longer transitively includes `<cstdint>` from standard library headers like `<string>`, `<memory>`, etc. Files using `uint32_t`, `uint64_t`, etc. without a direct or transitive path to `<cstdint>` fail to compile.

## Changes

### 1. Conditional `#include <cstdint>` behind `BUILD_LINUX` CMake flag

The `cstdint` includes are only added when building with `-DBUILD_LINUX=ON`, which defines `RAPIDSNARK_LINUX`. This keeps the fix scoped to Linux builds and avoids touching other platforms.

**CMakeLists.txt** (`src/CMakeLists.txt`):
```cmake
option(BUILD_LINUX "Build for Linux (adds cstdint includes needed by GCC 16+)" OFF)
if(BUILD_LINUX)
    add_definitions(-DRAPIDSNARK_LINUX)
endif()
```

**Source files** — each guarded with `#ifdef RAPIDSNARK_LINUX`:
- `src/binfile_utils.hpp` — `#include <cstdint>` after `<memory>` include
- `src/binfile_utils.cpp` — `#include <cstdint>` before project includes
- `src/zkey_utils.cpp` — `#include <cstdint>` before `<stdexcept>` include
- `src/random_generator.hpp` — `#include <cstdint>` after `<random>` include

**Usage:**
```sh
make host_linux
```

### 2. Workaround for GMP build (not a code change)

The `build_gmp.sh host` target fails because GMP's configure adds `-pedantic` which triggers an error in GCC 16's long long reliability test. Workaround:

```sh
cd depends/gmp
rm -rf build && mkdir build && cd build
../configure --prefix="$PWD/../../package" \
  --with-pic --disable-fft --enable-fat \
  CFLAGS="-O2 -fomit-frame-pointer -m64 -Wno-error" \
  CC="gcc -std=gnu11"
make -j$(nproc) && make install
```

The `-std=gnu11` flag allows the test code (which uses implicit function declarations) to compile without error.

## Notes

- Only 4 files needed `cstdint` fixes. All other source files either already included it directly (7 files) or received it transitively through `fr_element.hpp` / `fq_element.hpp` / `misc.hpp` (8 files).
- The non-standard `u_int32_t` / `u_int64_t` types (BSD extensions from `<sys/types.h>`) used in `binfile_utils`, `zkey_utils`, `groth16`, etc. remain unchanged — they compile on Linux via system header transitive includes but are a separate portability concern.

